### PR TITLE
Update net install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The `convertCMC` `egen` function can also address the situation in which the day
 
 `convertCMC` can be installed from within *Stata* by:
 ```
-net install convertCMC, from(https://bugbunny.github.io/convertCMC)
+net install convertCMC, from(https://raw.githubusercontent.com/bugbunny/convertCMC/gh-pages)
 ```
 
 DOI: [10.5281/zenodo.3557305](https://doi.org/10.5281/zenodo.3557305)


### PR DESCRIPTION
A net install from github.io balks at _gconvertCMC.ado for some reason